### PR TITLE
Change to use the ContentMode of the existing ImageView.

### DIFF
--- a/TMImageZoom.m
+++ b/TMImageZoom.m
@@ -8,7 +8,7 @@
 #import "TMImageZoom.h"
 
 static  TMImageZoom* tmImageZoom;
-@implementation BSImageZoom {
+@implementation TMImageZoom {
     UIImageView *currentImageView;
     UIImageView *hostImageView;
     BOOL isAnimatingReset;
@@ -66,7 +66,7 @@ static  TMImageZoom* tmImageZoom;
         
         // Init zoom ImageView
         currentImageView = [[UIImageView alloc] initWithImage:imageView.image];
-        currentImageView.contentMode = UIViewContentModeScaleAspectFill;
+        currentImageView.contentMode = imageView.contentMode;
         [currentImageView setFrame:startingRect];
         [currentWindow addSubview:currentImageView];
     }


### PR DESCRIPTION
Firstly, I appreciate this library lets me save a bunch of time.
However, when I install and use it, I find 2 problems.

The first change:
I don't know whether it is a typo, because I start from Swift and have no Objective-C experience. This change works for me with Swift 3.

The second change:
My ImageView is set to Aspect Fit, so it makes sense for me to reference that and reuse it. Otherwise, I see a zooming problem if currentImageView is set to Aspect Fill.